### PR TITLE
Bound the number of threads based on the number of CPUs

### DIFF
--- a/lib/fuse_loop_mt.c
+++ b/lib/fuse_loop_mt.c
@@ -187,7 +187,7 @@ int fuse_start_thread(pthread_t *thread_id, void *(*func)(void *), void *arg)
 
 #define FUSE_CLIENT_MAX_THREADS "FUSE_CLIENT_MAX_THREADS"
 
-static unsigned int getmaxthreadcount(void)
+static unsigned int get_max_thread_count(void)
 {
 	unsigned int maxthreads = UINT_MAX;
 
@@ -207,7 +207,7 @@ static unsigned int getmaxthreadcount(void)
 
 static int fuse_loop_start_thread(struct fuse_mt *mt)
 {
-    if (mt->numworker >= getmaxthreadcount()) {
+    if (mt->numworker >= get_max_thread_count()) {
         return 0;
     }
     

--- a/lib/fuse_loop_mt.c
+++ b/lib/fuse_loop_mt.c
@@ -197,7 +197,6 @@ static int fuse_loop_start_thread(struct fuse_mt *mt)
     /* We pick *2 to handle products using hard disks where there's */
     /* seek time and threads will be idle waiting for those seeks */
     if (mt->numworker >= cpus * 2) {
-        fprintf(stderr, "fuse: ran out of cpus %d\n", cpus);
         return 0;
     }
 #endif


### PR DESCRIPTION
Bound the number of cpus on MacOS to twice the number of cpus. We don't want to use stack memory per thread and we don't want to create a huge amount of threads based on the number of events we get.

Twice the number of CPUs is an intentional choice based on hardware using spinning disks and their seek time. This is a measured number based on HPE DL360s full of consumer based HDs.