### PR TITLE
Shifting a 32-bit signed int by 31 is an undefined behavior

### DIFF
--- a/include/fuse_common.h
+++ b/include/fuse_common.h
@@ -71,7 +71,7 @@ extern "C" {
 #define SETATTR_WANTS_CRTIME(attr)	((attr)->valid & (1 << 28))
 #define SETATTR_WANTS_CHGTIME(attr)	((attr)->valid & (1 << 29))
 #define SETATTR_WANTS_BKUPTIME(attr)	((attr)->valid & (1 << 30))
-#define SETATTR_WANTS_FLAGS(attr)	((attr)->valid & (1 << 31))
+#define SETATTR_WANTS_FLAGS(attr)	((attr)->valid & (1U << 31))
 
 struct setattr_x {
 	int32_t valid;
@@ -178,7 +178,7 @@ struct fuse_file_info {
 #  define FUSE_CAP_EXCHANGE_DATA	(1 << 28)
 #  define FUSE_CAP_CASE_INSENSITIVE	(1 << 29)
 #  define FUSE_CAP_VOL_RENAME		(1 << 30)
-#  define FUSE_CAP_XTIMES		(1 << 31)
+#  define FUSE_CAP_XTIMES		(1U << 31)
 #endif /* __APPLE__ */
 
 /**

--- a/include/fuse_kernel.h
+++ b/include/fuse_kernel.h
@@ -192,7 +192,7 @@ struct fuse_file_lock {
 #define FATTR_CRTIME	(1 << 28)
 #define FATTR_CHGTIME	(1 << 29)
 #define FATTR_BKUPTIME	(1 << 30)
-#define FATTR_FLAGS	(1 << 31)
+#define FATTR_FLAGS	(1U << 31)
 #endif
 
 /**
@@ -207,7 +207,7 @@ struct fuse_file_lock {
 #define FOPEN_NONSEEKABLE	(1 << 2)
 #ifdef __APPLE__
 #define FOPEN_PURGE_ATTR	(1 << 30)
-#define FOPEN_PURGE_UBC		(1 << 31)
+#define FOPEN_PURGE_UBC		(1U << 31)
 #endif
 
 /**
@@ -233,7 +233,7 @@ struct fuse_file_lock {
 #  define FUSE_EXCHANGE_DATA	(1 << 28)
 #  define FUSE_CASE_INSENSITIVE	(1 << 29)
 #  define FUSE_VOL_RENAME	(1 << 30)
-#  define FUSE_XTIMES		(1 << 31)
+#  define FUSE_XTIMES		(1U << 31)
 #endif
 
 /**

--- a/include/fuse_lowlevel.h
+++ b/include/fuse_lowlevel.h
@@ -156,7 +156,7 @@ struct fuse_forget_data {
 #define FUSE_SET_ATTR_CRTIME	(1 << 28)
 #define FUSE_SET_ATTR_CHGTIME	(1 << 29)
 #define FUSE_SET_ATTR_BKUPTIME	(1 << 30)
-#define FUSE_SET_ATTR_FLAGS	(1 << 31)
+#define FUSE_SET_ATTR_FLAGS	(1U << 31)
 #endif /* __APPLE__ */
 
 /* ----------------------------------------------------------- *


### PR DESCRIPTION
This caused libfuse-t to crash when compiled with Zig in the default configuration.