### PR TITLE
allow passing --namedattr=true to FUSE_NFSSRV_PROG

### DIFF
--- a/lib/mount_darwin.c
+++ b/lib/mount_darwin.c
@@ -62,6 +62,7 @@ enum {
 	KEY_NOATIME,
 	KEY_NOMTIME,
 	KEY_NFC,
+	KEY_NAMEDATTR,
 };
 
 struct mount_opts {
@@ -75,6 +76,7 @@ struct mount_opts {
 	char *listen_addr;
 	int read_only;
 	int nonamedattr;
+	int namedattr;
 	int noattrcache;
 	int rwsize;
 	int nobrowse;
@@ -205,6 +207,7 @@ static const struct fuse_opt fuse_mount_opts[] = {
 	FUSE_OPT_KEY("-d",		     	  KEY_DEBUG),
 	{ "listen_addr=%s", offsetof(struct mount_opts, listen_addr), 0 },
 	FUSE_OPT_KEY("nonamedattr",	      KEY_NONAMEDATTR),
+	FUSE_OPT_KEY("namedattr",	      KEY_NAMEDATTR),
 	FUSE_OPT_KEY("nfc",	      		KEY_NFC),
 	{ "rwsize=%d", offsetof(struct mount_opts, rwsize), 0 },
 	FUSE_OPT_KEY("noatime",	      	KEY_NOATIME),
@@ -286,6 +289,9 @@ fuse_mount_opt_proc(void *data, const char *arg, int key,
 			break;
 		case KEY_NONAMEDATTR:
 			mo->nonamedattr = 1;
+			return 0;
+		case KEY_NAMEDATTR:
+			mo->namedattr = 1;
 			return 0;
 		case KEY_NOATTRCACHE:
 			mo->noattrcache = 1;
@@ -547,6 +553,9 @@ fuse_mount_core(const char *mountpoint, struct mount_opts *mopts,
 		}
 		if (mopts->nonamedattr) {
 			argv[a++] = "--namedattr=false";
+		}
+		if (mopts->namedattr) {
+			argv[a++] = "--namedattr=true";
 		}
 		if (mopts->noattrcache) {
 			argv[a++] = "--attrcache=false";


### PR DESCRIPTION
According to the mount_nfs documentation, nonamedattr is the default NFS_V4 mounts. The argument parsing in libfuse does not appear to support --nonamedattr=false. To enable named attribute support when running the underlying FUSE_NFSSRV_PROG, a separate command line option is needed to pass the option through from libfuse to FUSE_NFSSERV_PROG.

```
λ man mount_nfs | col -b | grep nonamedattr -A 2
     nonamedattr
	     For NFSv4 mounts, don't support named attributes even if the
	     server does. This is the default.
```

The help output for go-nfsv4 indicates that `--namedattr` support exists, but I don't currently see a way to enable it.
```
λ /usr/local/bin/go-nfsv4 --help
Usage of /usr/local/bin/go-nfsv4:
      --attrcache               cache attributes (default true)
      --attrcache-timeout int   non-default attribute cache timeout (sec)
      --backend string          backend (default "nfs")
  -c, --console                 output logs to console
  -d, --debug                   debug mode
      --dontbrowse              don't browse mount option
  -l, --listen_addr string      nfs server listen address
      --location string         location (default "fuse-t")
      --logfile string          log file path (default "/Users/adam/Library/Logs/fuse-t/fuse-t.log")
      --namedattr               named attributes support
      --nfc                     nfc encoding
      --noatime                 don't set access time
      --nomtime                 don't set modify time
  -r, --readonly                read-only
      --rwsize int              read/write buffer size
  -n, --volname string          volume name
pflag: help requested
```

Using `cgofuse` and passing `-onamedattr` results in `fuse: unknown option namedattr` before this change. After building the framework locally including this change, the parsing succeeds and I see go-nfsv4 running via ps, but something seems wrong with the communication between the dylib and the nfs server. I'm not sure if that's because there is something wrong with my local build of the dylib though.

```
λ ps -ef | grep 96094
...
  502 96096 96094   0 11:31AM ??         0:00.02 ...Products/Debug/fuse_t.framework/Resources/go-nfsv4 -d --volname xyz --namedattr=true /Users/adam/foo
```