### PR TITLE
Fix clean exit after unmount with NFS backend

### DIFF
--- a/lib/fuse_kern_chan.c
+++ b/lib/fuse_kern_chan.c
@@ -64,10 +64,17 @@ again:
 			state++;
 			total += res;
 		}
-			
+
 		err = errno;
 
 		if (fuse_session_exited(se)) {
+			return 0;
+		}
+		/* recv() returns 0 on EOF (socket closed). This happens
+		 * during normal unmount when the NFS backend tears down
+		 * the connection. Treat it as a clean session exit. */
+		if (res == 0) {
+			fuse_session_exit(se);
 			return 0;
 		}
 		if (res == -1) {

--- a/lib/fuse_signals.c
+++ b/lib/fuse_signals.c
@@ -82,6 +82,9 @@ void fuse_remove_signal_handlers(struct fuse_session *se)
 	set_one_signal_handler(SIGHUP, exit_handler, 1);
 	set_one_signal_handler(SIGINT, exit_handler, 1);
 	set_one_signal_handler(SIGTERM, exit_handler, 1);
-	set_one_signal_handler(SIGPIPE, SIG_IGN, 1);
+	/* FUSE-T uses sockets (NFS backend) instead of /dev/fuse.
+	 * SIGPIPE must stay ignored because socket writes can occur
+	 * during cleanup after the peer closes the connection.
+	 * Do NOT restore SIGPIPE to SIG_DFL here. */
 }
 


### PR DESCRIPTION
## Problem

When a FUSE filesystem using FUSE-T unmounts (via `umount` or `diskutil unmount`), the process exits with a non-zero exit code instead of exiting cleanly. Two issues cause this:

1. **`fuse_kern_chan.c`**: `recv()` returns 0 (EOF) when the NFS socket closes during unmount. This falls through to the "short read" check which returns `-EIO`, causing `fuse_main()` to return an error. (The `fprintf` for "short read on fuse device" was already commented out, but the `-EIO` return remains.)

2. **`fuse_signals.c`**: `fuse_remove_signal_handlers()` restores `SIGPIPE` to `SIG_DFL`. Since FUSE-T uses sockets (not `/dev/fuse`), `writev()` during cleanup gets `SIGPIPE` when the peer has closed the connection, killing the process (exit 141 = 128 + SIGPIPE).

With macFUSE (kext-based), unmount sends `ENODEV` which libfuse handles cleanly. FUSE-T's NFS backend produces different teardown behavior that the current code doesn't handle.

This was previously reported in https://github.com/macos-fuse-t/fuse-t/issues/91:

> my program shows an error "short read on fuse device" and then exits due to "broken pipe". The destructors are not called and cleanup is not performed.

## Fix

**`fuse_kern_chan.c`** — treat `recv() == 0` as a clean session exit (same as `ENODEV`):
```c
if (res == 0) {
    fuse_session_exit(se);
    return 0;
}
```

**`fuse_signals.c`** — don't restore `SIGPIPE` to `SIG_DFL` in `fuse_remove_signal_handlers()`, since socket writes can occur during cleanup after the NFS peer closes:
```c
/* FUSE-T uses sockets (NFS backend) instead of /dev/fuse.
 * SIGPIPE must stay ignored because socket writes can occur
 * during cleanup after the peer closes the connection.
 * Do NOT restore SIGPIPE to SIG_DFL here. */
```

## Validation

This issue was discovered while adding FUSE-T support to the [tup](https://github.com/gittup/tup) build system as a replacement for macFUSE. Tested with tup on macOS ARM64 with FUSE-T 1.0.49. Without the fix, tup exits non-zero after every FUSE operation, making it unusable with FUSE-T. With the fix, tup bootstraps (builds itself using FUSE) and its test suite runs successfully.

## Reproducer

The following test program demonstrates the issue. It should exit 0 but exits non-zero without the fix:

```c
/*
 * Test: FUSE-T unmount produces clean exit code.
 *
 * Build:
 *   cc test_unmount_exit.c -o test_unmount_exit \
 *     $(pkg-config fuse --cflags --libs)
 *
 * Run:
 *   ./test_unmount_exit
 *
 * Expected: "PASS: FUSE process exited cleanly after unmount"
 * Without fix: "FAIL: FUSE process killed by signal 13 (SIGPIPE)"
 *              or "FAIL: FUSE process exited with code N"
 */

#define FUSE_USE_VERSION 26

#include <fuse.h>
#include <stdio.h>
#include <stdlib.h>
#include <string.h>
#include <errno.h>
#include <fcntl.h>
#include <unistd.h>
#include <sys/stat.h>
#include <sys/wait.h>
#include <signal.h>

static const char *test_path = "/testfile";
static const char *test_content = "unmount test\n";

static int test_getattr(const char *path, struct stat *stbuf)
{
    memset(stbuf, 0, sizeof(struct stat));
    if (strcmp(path, "/") == 0) {
        stbuf->st_mode = S_IFDIR | 0755;
        stbuf->st_nlink = 2;
        return 0;
    }
    if (strcmp(path, test_path) == 0) {
        stbuf->st_mode = S_IFREG | 0444;
        stbuf->st_nlink = 1;
        stbuf->st_size = strlen(test_content);
        return 0;
    }
    return -ENOENT;
}

static int test_readdir(const char *path, void *buf, fuse_fill_dir_t filler,
                        off_t offset, struct fuse_file_info *fi)
{
    (void)offset; (void)fi;
    if (strcmp(path, "/") != 0) return -ENOENT;
    filler(buf, ".", NULL, 0);
    filler(buf, "..", NULL, 0);
    filler(buf, test_path + 1, NULL, 0);
    return 0;
}

static int test_open(const char *path, struct fuse_file_info *fi)
{
    if (strcmp(path, test_path) != 0) return -ENOENT;
    if ((fi->flags & 3) != O_RDONLY) return -EACCES;
    return 0;
}

static int test_read(const char *path, char *buf, size_t size, off_t offset,
                     struct fuse_file_info *fi)
{
    size_t len;
    (void)fi;
    if (strcmp(path, test_path) != 0) return -ENOENT;
    len = strlen(test_content);
    if ((size_t)offset < len) {
        if (offset + size > len) size = len - (size_t)offset;
        memcpy(buf, test_content + offset, size);
    } else {
        size = 0;
    }
    return size;
}

static struct fuse_operations test_oper = {
    .getattr = test_getattr,
    .readdir = test_readdir,
    .open = test_open,
    .read = test_read,
};

int main(int argc, char *argv[])
{
    char mntdir[] = "/tmp/fuse_test_unmount_XXXXXX";
    char cmd[512];
    pid_t child;
    int status, rc = 0;
    (void)argc; (void)argv;

    if (mkdtemp(mntdir) == NULL) { perror("mkdtemp"); return 1; }

    child = fork();
    if (child < 0) { perror("fork"); rmdir(mntdir); return 1; }

    if (child == 0) {
        char *fuse_argv[] = {"test", "-f", "-s", mntdir, NULL};
        _exit(fuse_main(4, fuse_argv, &test_oper, NULL));
    }

    /* Wait for mount */
    char testfile[512];
    snprintf(testfile, sizeof(testfile), "%s/testfile", mntdir);
    for (int i = 0; i < 50; i++) {
        if (access(testfile, R_OK) == 0) break;
        usleep(100000);
    }

    /* Read through FUSE */
    FILE *f = fopen(testfile, "r");
    if (f) { char buf[256]; fgets(buf, sizeof(buf), f); fclose(f); }

    /* Unmount */
    snprintf(cmd, sizeof(cmd),
        "umount '%s' 2>/dev/null || diskutil unmount '%s' 2>/dev/null",
        mntdir, mntdir);
    system(cmd);

    /* Check exit code */
    waitpid(child, &status, 0);
    if (WIFSIGNALED(status)) {
        fprintf(stderr, "FAIL: killed by signal %d%s\n",
            WTERMSIG(status),
            WTERMSIG(status) == SIGPIPE ? " (SIGPIPE)" : "");
        rc = 1;
    } else if (WIFEXITED(status) && WEXITSTATUS(status) != 0) {
        fprintf(stderr, "FAIL: exited with code %d\n", WEXITSTATUS(status));
        rc = 1;
    }
    rmdir(mntdir);
    if (rc == 0) printf("PASS: FUSE process exited cleanly after unmount\n");
    return rc;
}
```

This test is not included in this PR since the repository does not currently have a test suite. It is provided here for review and validation.

## Also affects

- https://github.com/mpartel/bindfs/issues/135 — bindfs test suite fails with fuse-t

---

*This issue was identified and fixed with the help of [Claude Code](https://claude.com/claude-code) (Anthropic's AI coding assistant) while adding FUSE-T support to the [tup](https://github.com/gittup/tup) build system as a replacement for macFUSE.*